### PR TITLE
fix(vkgltablemapper): check if anchor can be removed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         kubernetes {
-            label 'molgenis'
+            label 'molgenis-jdk11'
         }
     }
     stages {

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,28 @@
       <artifactId>camel-jackson</artifactId>
     </dependency>
 
+    <!-- Extra dependencies to migrate to Java 11-->
+    <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+
     <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-csv -->
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/main/java/org/molgenis/mappers/VkglTableMapper.java
+++ b/src/main/java/org/molgenis/mappers/VkglTableMapper.java
@@ -11,14 +11,15 @@ public interface VkglTableMapper {
     return Hasher.hash(id);
   }
 
-  default Map<String, String> getCorrectedRefAndAlt(String ref, String alt, String type,
-      int start) {
+  default Map<String, String> getCorrectedRefAndAlt(String ref, String alt, int start) {
     HashMap<String, String> corrected = new HashMap<>();
-    if (type.equals("sub") && ref.length() == 2 && alt.length() == 2) {
+
+    if (alt.length() > 1 && ref.length() > 1 && ref.charAt(0) == alt.charAt(0)) {
       ref = ref.substring(1);
       alt = alt.substring(1);
       start += 1;
     }
+
     corrected.put("ref", ref);
     corrected.put("alt", alt);
     corrected.put("start", Integer.toString(start));
@@ -57,7 +58,7 @@ public interface VkglTableMapper {
     body.put("type", type);
     body.put("chromosome", chromosome);
 
-    Map<String, String> corrected = getCorrectedRefAndAlt(refOrig, altOrig, type, start);
+    Map<String, String> corrected = getCorrectedRefAndAlt(refOrig, altOrig, start);
     body.putAll(corrected);
 
     String id = getId(corrected.get("ref"), corrected.get("alt"), chromosome,

--- a/src/test/java/org/molgenis/mappers/AlissaVkglTableMapperTest.java
+++ b/src/test/java/org/molgenis/mappers/AlissaVkglTableMapperTest.java
@@ -13,10 +13,9 @@ class AlissaVkglTableMapperTest {
   @Test
   void getCorrectedRefAndAltSubTest() {
     String ref = "AA";
-    String alt = "CC";
-    String type = "sub";
+    String alt = "AC";
     int start = 123;
-    Map observed = alissa.getCorrectedRefAndAlt(ref, alt, type, start);
+    Map observed = alissa.getCorrectedRefAndAlt(ref, alt, start);
     Map<String, String> expected = new HashMap<String, String>() {{
       put("ref", "A");
       put("alt", "C");
@@ -29,13 +28,40 @@ class AlissaVkglTableMapperTest {
   void getCorrectedRefAndAltDelTest() {
     String ref = "AA";
     String alt = "A";
-    String type = "del";
     int start = 123;
-    Map observed = alissa.getCorrectedRefAndAlt(ref, alt, type, start);
+    Map observed = alissa.getCorrectedRefAndAlt(ref, alt, start);
     Map<String, String> expected = new HashMap<String, String>() {{
       put("ref", "AA");
       put("alt", "A");
       put("start", "123");
+    }};
+    assertEquals(expected, observed);
+  }
+
+  @Test
+  void getCorrectedRefAndAltInsTest() {
+    String ref = "A";
+    String alt = "AA";
+    int start = 123;
+    Map observed = alissa.getCorrectedRefAndAlt(ref, alt, start);
+    Map<String, String> expected = new HashMap<String, String>() {{
+      put("ref", "A");
+      put("alt", "AA");
+      put("start", "123");
+    }};
+    assertEquals(expected, observed);
+  }
+
+  @Test
+  void getCorrectedRefAndAltInDelTest() {
+    String ref = "ATGGAGAGACAGCGAGAAGACCAGGAAC";
+    String alt = "AAGA";
+    int start = 91670141;
+    Map observed = alissa.getCorrectedRefAndAlt(ref, alt, start);
+    Map<String, String> expected = new HashMap<String, String>() {{
+      put("ref", "TGGAGAGACAGCGAGAAGACCAGGAAC");
+      put("alt", "AGA");
+      put("start", "91670142");
     }};
     assertEquals(expected, observed);
   }
@@ -78,7 +104,7 @@ class AlissaVkglTableMapperTest {
   void mapLineTest() {
     Map<String, Object> body = new HashMap<>();
     body.put("ref", "AA");
-    body.put("alt", "GG");
+    body.put("alt", "AG");
     body.put("type", "sub");
     body.put("chrom", "X");
     body.put("pos", 124);

--- a/src/test/java/org/molgenis/mappers/LumcVkglTableMapperTest.java
+++ b/src/test/java/org/molgenis/mappers/LumcVkglTableMapperTest.java
@@ -23,7 +23,7 @@ class LumcVkglTableMapperTest {
   void mapLineTest() {
     Map<String, Object> body = new HashMap<>();
     body.put("ref", "AA");
-    body.put("alt", "GG");
+    body.put("alt", "AG");
     body.put("type", "sub");
     body.put("chrom", "X");
     body.put("pos", 124);


### PR DESCRIPTION
Before the anchor was only removed for the substitution variants, but anchors should be removed from
indels as well