### PR TITLE
Fix: Missing variants when processing multiple labs at once

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
       <artifactId>camel-spring-boot-starter</artifactId>
       <version>${camel-version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-http-starter</artifactId>
+      <version>${camel-version}</version>
+    </dependency>
 
     <!-- Extra dependencies to migrate to Java 11-->
     <dependency>

--- a/src/main/java/org/molgenis/core/MySpringBootRouter.java
+++ b/src/main/java/org/molgenis/core/MySpringBootRouter.java
@@ -175,7 +175,7 @@ public class MySpringBootRouter extends RouteBuilder {
         .completionTimeout(DEFAULT_TIMEOUT)
         .recipientList(simple(
             "direct:marshal-${header.labType}-result,direct:map-${header.labType}-result"))
-        .delay(30000)
+        .delay(10000)
         .to("log:done");
 
     from("direct:check_unique")

--- a/src/main/java/org/molgenis/core/MySpringBootRouter.java
+++ b/src/main/java/org/molgenis/core/MySpringBootRouter.java
@@ -173,9 +173,9 @@ public class MySpringBootRouter extends RouteBuilder {
         .routeId("writeResultRoute")
         .aggregate(header(FILE_NAME), new GroupedBodyAggregationStrategy())
         .completionTimeout(DEFAULT_TIMEOUT)
-        .to("log:done")
         .recipientList(simple(
-            "direct:marshal-${header.labType}-result,direct:map-${header.labType}-result"));
+            "direct:marshal-${header.labType}-result,direct:map-${header.labType}-result"))
+        .to("log:done");
 
     from("direct:check_unique")
         .routeId("checkUniqueRoute")

--- a/src/main/java/org/molgenis/core/MySpringBootRouter.java
+++ b/src/main/java/org/molgenis/core/MySpringBootRouter.java
@@ -175,6 +175,7 @@ public class MySpringBootRouter extends RouteBuilder {
         .completionTimeout(DEFAULT_TIMEOUT)
         .recipientList(simple(
             "direct:marshal-${header.labType}-result,direct:map-${header.labType}-result"))
+        .delay(30000)
         .to("log:done");
 
     from("direct:check_unique")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # the name of Camel
 camel.springboot.name=VKGL
 # how long the application should wait for the file to complete
-completion.timeout=60000
+completion.timeout=300000
 # to automatic shutdown the JVM after a period of time
 #camel.springboot.duration-max-seconds=60
 #camel.springboot.duration-max-messages=100
@@ -19,3 +19,6 @@ management.endpoint.camelroutes.read-only=true
 #logging.level.org.apache.camel.spring.boot = INFO
 #logging.level.org.apache.camel.impl = DEBUG
 #logging.level.sample.camel = DEBUG
+# HTTP component configuration
+connectTimeout=5000
+socketTimeout=30000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,7 +20,7 @@ management.endpoint.camelroutes.read-only=true
 #logging.level.org.apache.camel.impl = DEBUG
 #logging.level.sample.camel = DEBUG
 # HTTP component configuration
-connectionsPerRoute=1
-maxTotalConnections=1
-connectTimeout=5000
-socketTimeout=30000
+camel.component.http.connect-timeout=5000
+camel.component.http.socket-timeout=30000
+camel.component.http.max-total-connections=1
+camel.component.http.connections-per-route=1

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,5 +20,7 @@ management.endpoint.camelroutes.read-only=true
 #logging.level.org.apache.camel.impl = DEBUG
 #logging.level.sample.camel = DEBUG
 # HTTP component configuration
+connectionsPerRoute=1
+maxTotalConnections=1
 connectTimeout=5000
 socketTimeout=30000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,7 +20,7 @@ management.endpoint.camelroutes.read-only=true
 #logging.level.org.apache.camel.impl = DEBUG
 #logging.level.sample.camel = DEBUG
 # HTTP component configuration
-camel.component.http.connect-timeout=10000
-camel.component.http.socket-timeout=50000
+camel.component.http.connect-timeout=5000
+camel.component.http.socket-timeout=30000
 camel.component.http.max-total-connections=1
 camel.component.http.connections-per-route=1

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,7 +20,7 @@ management.endpoint.camelroutes.read-only=true
 #logging.level.org.apache.camel.impl = DEBUG
 #logging.level.sample.camel = DEBUG
 # HTTP component configuration
-camel.component.http.connect-timeout=5000
-camel.component.http.socket-timeout=30000
+camel.component.http.connect-timeout=10000
+camel.component.http.socket-timeout=50000
 camel.component.http.max-total-connections=1
 camel.component.http.connections-per-route=1


### PR DESCRIPTION
Issue: When multiple labs were submitted in the inbox at once, variants would miss from a number of files without an error being reported. So we silently have a invalid export.

The problems:
1) The variant validator is singletheaded, so there should only be sended a new request once the previous one is done. This was fixed by adding these properties to the `application.properties`:
```
camel.component.http.max-total-connections=1
camel.component.http.connections-per-route=1 
```
2) It took too long for the request to respond, so we set some timeouts:
```
camel.component.http.connect-timeout=5000
camel.component.http.socket-timeout=30000
```
3) When all files were created the pipeline reported `done` in the log and was shut down immediately. The problem was that the `done` log was a bit too early, causing the last file to be processed to be incomplete. To fix this, the done statement was moved down as much as possible and delayed with 10 seconds. 